### PR TITLE
Multi-architecture support

### DIFF
--- a/custom_components/ha_vscode/vscode_device.py
+++ b/custom_components/ha_vscode/vscode_device.py
@@ -17,6 +17,11 @@ if not "PACKAGE_NAME" in globals():
 
 LOGGER: logging.Logger = logging.getLogger(PACKAGE_NAME)
 
+architecture_map = {
+    "x86_64": "x64",
+    "armv7l": "armhf",
+    "aarch64": "arm64",
+}
 
 class VSCodeDeviceAPI:
     """Command line VSCode Tunnel OAuth device flow"""
@@ -51,10 +56,11 @@ class VSCodeDeviceAPI:
     def downloadViaCurl(self, outdir):
         # curl -Lk https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64 --output /workspaces/ha_core/config/custom_components/ha_vscode/bin/vscode_cli.tar.gz
         result = None
+        architecture = os.uname().machine
         getVSCodeCLIcurl = [
             "curl",
             "-Lk",
-            "https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64",
+            f"https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-{architecture_map[architecture]}",
             "--output",
             outdir,
         ]
@@ -83,9 +89,10 @@ class VSCodeDeviceAPI:
         # wget https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64 -O /workspaces/ha_core/config/custom_components/ha_vscode/bin/vscode_cli.tar.gz
 
         result = None
+        architecture = os.uname().machine
         getVSCodeCLIwget = [
             "wget",
-            "https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-x64",
+            f"https://code.visualstudio.com/sha/download?build=stable&os=cli-alpine-{architecture_map[architecture]}",
             "-O",
             outdir,
         ]


### PR DESCRIPTION
First of all, thank you for this component, I was searching for this for a long time (in fact I was thinking to do the same).

I'm using a RPi CM4 for my home assistant server, so when I tried this I was getting an error because it was trying to execute an x64 binary when the system was ARM64, so I made the modifications to ask the system for its architecture and depending on that, download one or another binary file.