### PR TITLE
Fix for #4 async_forward_entry_setup is deprecated

### DIFF
--- a/custom_components/ha_vscode/__init__.py
+++ b/custom_components/ha_vscode/__init__.py
@@ -13,8 +13,5 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     # Add sensor
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True

--- a/custom_components/ha_vscode/__init__.py
+++ b/custom_components/ha_vscode/__init__.py
@@ -14,7 +14,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     # Add sensor
     for platform in PLATFORMS:
-        hass.async_add_job(
+        hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
     return True


### PR DESCRIPTION
Fix for #4 

Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/